### PR TITLE
docs: local run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **static GitHub Pages portfolio** (HTML/CSS/JS). There is no `package.json`, Docker stack, database, or build step.
+
+### Running locally
+
+Serve the repo root with any static HTTP server. Relative asset paths require HTTP (not `file://`).
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://127.0.0.1:8000/` (landing) or project paths under `/projects/` (e.g. `http://127.0.0.1:8000/projects/todoList/`).
+
+### Services
+
+| Service | Role |
+|---------|------|
+| Static HTTP server | **Required** — only in-repo “runtime” |
+| Internet / CDNs | **Often needed** — Bootstrap, jQuery, fonts, Font Awesome load from CDNs on many pages |
+| Ron Swanson API | **Optional** — only for `/projects/ron-swanson/` quote buttons |
+| External Heroku apps | **Optional** — linked from portfolio pages; not in this repo |
+
+### Lint / test / build
+
+There are no in-repo lint configs, test runners, or build commands. Validation is manual: serve static files and verify pages in a browser.
+
+### Long-running dev server
+
+Use **tmux** for the HTTP server so it survives across agent steps, e.g. session name `static-http-server` with `python3 -m http.server 8000` from `/workspace`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for this static GitHub Pages portfolio.

## Summary
- Documents how to serve the site locally (`python3 -m http.server`)
- Lists required vs optional external dependencies (CDNs, Ron Swanson API, etc.)
- Notes there is no in-repo lint/test/build pipeline

No application code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d9e5292-28f0-46ad-8fce-2ecd84996081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d9e5292-28f0-46ad-8fce-2ecd84996081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

